### PR TITLE
Fix typo in notifications tab

### DIFF
--- a/desktop/php/alarme_IMA.php
+++ b/desktop/php/alarme_IMA.php
@@ -60,7 +60,7 @@ foreach ($eqLogics as $eqLogic) {
 	<li role="presentation">
 		<a href="#tabNotifications" aria-controls="home" role="tab" data-toggle="tab">
 			<i class="fas fa-bell"></i> 
-			{{Notiifcations}}
+			{{Notifications}}
 		</a>
 	</li>
     <li role="presentation">


### PR DESCRIPTION
Hello there,

A very small PR to fix a typo in the "Notifications" tab of the plugin.

![image](https://user-images.githubusercontent.com/5130468/204106059-01dab93b-9e36-4550-99d9-a310b7711e49.png)

On a side note, thanks for the plugin! Just started using it, but great surprise to see that it already existed on the marketplace 🙌

Cheers,
Guillaume